### PR TITLE
Fix bug when player tries to play previously played position

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,16 +44,8 @@ function updateGameInfo(string) {
 /*~~~~~~~~~~~~~~~~~~GAME FUNCTIONS~~~~~~~~~~~~~~~~~~~~*/
 function takeTurn(e) {
 	if (currentGame.currentPlayer === 1) {
-		updateGameInfo("Turn: Player 2");
-		add(player2Box, "active");
-		remove(player1Box, "active");
-		currentGame.currentPlayer = 2;
 		choosePosition(player1, e.target.id);
 	} else if (currentGame.currentPlayer === 2) {
-		updateGameInfo("Turn: Player 1");
-		add(player1Box, "active");
-		remove(player2Box, "active");
-		currentGame.currentPlayer = 1;
 		choosePosition(player2, e.target.id);
 	}
 }
@@ -66,7 +58,22 @@ function choosePosition(player, position) {
 			placeToken(player, position);
 			bleep.play();
 			checkWinOrDraw(player);
+			changePlayer()
 		}
+	}
+}
+
+function changePlayer() {
+	if (currentGame.currentPlayer === 1) {
+		updateGameInfo("Turn: Player 2");
+		add(player2Box, "active");
+		remove(player1Box, "active");
+		currentGame.currentPlayer = 2;
+	} else if (currentGame.currentPlayer === 2) {
+		updateGameInfo("Turn: Player 1");
+		add(player1Box, "active");
+		remove(player2Box, "active");
+		currentGame.currentPlayer = 1;
 	}
 }
 


### PR DESCRIPTION
# Description

Last minute bug discovery. This bug with duplicate plays must have occurred upon refactor. I have made a fix which rectifies the issue.

Fixes # (issue)
Player turn changed when clicking on previously used square. Issue now fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
