### PR TITLE
Move changePlayer above checkWinOrDraw to fix diplay issue.

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,8 +57,8 @@ function choosePosition(player, position) {
 			player.choices.push(position);
 			placeToken(player, position);
 			bleep.play();
-			checkWinOrDraw(player);
 			changePlayer();
+			checkWinOrDraw(player);
 		}
 	}
 }


### PR DESCRIPTION
# Description


Fixes # (winner/draw on screen annoucement)

Upon refactoring it appears I moved the changePlayer function below the checkForWin function which was causing the winner or draw announcements to disappear. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
